### PR TITLE
OpenMPI 3 on docker fails to run reg tests when multiple mpi comm wor…

### DIFF
--- a/python/reg_tests/mdo_regression_compare.py
+++ b/python/reg_tests/mdo_regression_compare.py
@@ -1,0 +1,110 @@
+from __future__ import print_function
+# This file contains two functions to help regression testing. The
+# first is used to format float values with a specified absolute and
+# relative tolerance. This information is used by the second function
+# when it takes in two such formatted strings and decides if they are
+# sufficiently close to be considered equal.
+import os
+import sys
+REG_FILES_MATCH = 0
+REG_FILES_DO_NOT_MATCH = 1
+REG_ERROR = -1
+
+def _reg_str_comp(str1, str2):
+    '''Compare the float values in str1 and str2 and determine if they
+    are equal. Returns True if they are the "same", False if different'''
+
+    aux1 = str1.split()
+    aux2 = str2.split()
+
+    if not aux1[0] == aux2[0] == '@value':
+        # This line does not need to be compared
+        return True
+
+    # Extract required tolerances and values
+    rel_tol = float(aux1[2])
+    abs_tol = float(aux1[3])
+    val1 = float(aux1[1])
+    val2 = float(aux2[1])
+
+    rel_err = 0
+    if val2 != 0:
+        rel_err = abs((val1-val2)/val2)
+    else:
+        rel_err = abs((val1-val2)/(val2 + 1e-16))
+
+    abs_err = abs(val1-val2)
+
+    if abs_err < abs_tol or rel_err < rel_tol:
+        return True
+    else:
+        return False
+
+
+def reg_file_comp(ref_file, comp_file):
+    '''Compare the reference file 'ref_file' with 'comp_file'. The
+    order of these two files matter. The ref_file MUST be given
+    first. Only values specified by reg_write() are compared.  All
+    other lines are ignored. Floating point values are compared based
+    on rel_tol and abs_tol'''
+
+    all_ref_lines = []
+    ref_values = []
+    comp_values = []
+    try:
+        f = open(ref_file, 'r')
+    except IOError:
+        print('File %s was not found. Cannot do comparison.'% ref_file)
+        return REG_ERROR
+    for line in f.readlines():
+        all_ref_lines.append(line)
+        if line[0:6] == '@value':
+            ref_values.append(line)
+
+    f.close()
+
+    try:
+        f = open(comp_file, 'r')
+    except IOError:
+        print('File %s was not found. Cannot do comparison.'% comp_file)
+        return REG_ERROR
+
+    for line in f.readlines():
+        if line[0:6] == '@value':
+            comp_values.append(line)
+
+    f.close()
+
+    # Copy the comp_file to compe_file.orig
+    os.system('cp %s %s.orig'% (comp_file, comp_file))
+
+    # We must check that we have the same number of @value's to compare:
+    if len(ref_values) != len(comp_values):
+        print('Error: number of @value lines in file not the same!')
+        return REG_FILES_DO_NOT_MATCH
+
+    # Open the (new) comp_file:
+    f = open(comp_file,'w')
+
+    # Loop over all the ref_lines, for value lines, do the
+    # comparison. If comparison is ok, write the ref line, otherwise
+    # write orig line.
+
+    j = 0
+    res = REG_FILES_MATCH
+    for i in range(len(all_ref_lines)):
+        line = all_ref_lines[i]
+        if line[0:6] == '@value':
+            if _reg_str_comp(line, comp_values[j]) is False:
+                f.write(comp_values[j])
+                res = REG_FILES_DO_NOT_MATCH
+            else:
+                f.write(line)
+
+            j += 1
+        else:
+            f.write(line)
+
+    f.close()
+
+    return res

--- a/python/reg_tests/mdo_regression_helper.py
+++ b/python/reg_tests/mdo_regression_helper.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 # first is used to format float values with a specified absolute and
 # relative tolerance. This information is used by the second function
 # when it takes in two such formatted strings and decides if they are
-# sufficiently close to be considered equal. 
+# sufficiently close to be considered equal.
 import numpy, os
 from mpi4py import MPI
 import sys
@@ -25,7 +25,7 @@ def reg_write(values, rel_tol=1e-12, abs_tol=1e-12):
     for val in values:
         s = '@value %20.13e %g %g'% (val, rel_tol, abs_tol)
         print(s)
- 
+
     return
 
 def reg_par_write(values, rel_tol=1e-12, abs_tol=1e-12):
@@ -79,19 +79,19 @@ def _reg_str_comp(str1, str2):
     if not aux1[0] == aux2[0] == '@value':
         # This line does not need to be compared
         return True
-    
+
     # Extract required tolerances and values
     rel_tol = float(aux1[2])
     abs_tol = float(aux1[3])
     val1 = float(aux1[1])
     val2 = float(aux2[1])
-    
+
     rel_err = 0
     if val2 != 0:
         rel_err = abs((val1-val2)/val2)
     else:
         rel_err = abs((val1-val2)/(val2 + 1e-16))
-        
+
     abs_err = abs(val1-val2)
 
     if abs_err < abs_tol or rel_err < rel_tol:
@@ -106,7 +106,7 @@ def reg_file_comp(ref_file, comp_file):
     first. Only values specified by reg_write() are compared.  All
     other lines are ignored. Floating point values are compared based
     on rel_tol and abs_tol'''
-    
+
     all_ref_lines = []
     ref_values = []
     comp_values = []
@@ -141,20 +141,20 @@ def reg_file_comp(ref_file, comp_file):
     if len(ref_values) != len(comp_values):
         print('Error: number of @value lines in file not the same!')
         return REG_FILES_DO_NOT_MATCH
-    
+
     # Open the (new) comp_file:
     f = open(comp_file,'w')
 
     # Loop over all the ref_lines, for value lines, do the
     # comparison. If comparison is ok, write the ref line, otherwise
-    # write orig line. 
+    # write orig line.
 
     j = 0
     res = REG_FILES_MATCH
     for i in range(len(all_ref_lines)):
         line = all_ref_lines[i]
         if line[0:6] == '@value':
-            if _reg_str_comp(line, comp_values[j]) is False:            
+            if _reg_str_comp(line, comp_values[j]) is False:
                 f.write(comp_values[j])
                 res = REG_FILES_DO_NOT_MATCH
             else:
@@ -199,8 +199,7 @@ if __name__ == '__main__':
 
     else:
         res = reg_file_comp(sys.argv[1], sys.argv[2])
-        if res == 0: 
+        if res == 0:
             print ('Success!')
-        elif res == 1: 
+        elif res == 1:
             print ('Failure!')
-

--- a/python/reg_tests/run_reg_tests.py
+++ b/python/reg_tests/run_reg_tests.py
@@ -1,13 +1,13 @@
 from __future__ import print_function
 # =============================================================================
-# Standard Python modules                                           
+# Standard Python modules
 # =============================================================================
 import os, sys, argparse, glob
 
 # =============================================================================
 # Extension modules
 # =============================================================================
-import mdo_regression_helper as reg
+import mdo_regression_compare as reg
 
 # define scripts to run:
 module_name = 'adflow'
@@ -23,7 +23,7 @@ parser.add_argument("--procs",default=4, type=int,
 parser.add_argument("--diff_cmd",default='xxdiff',
                     help='Command to run for displaying diff. Default: xxdiff')
 
-parser.add_argument("--diff", action='store_true', default=False, 
+parser.add_argument("--diff", action='store_true', default=False,
                     help='Display error diffs for each test.')
 
 parser.add_argument("--mpiexec",default='mpirun',
@@ -32,7 +32,7 @@ parser.add_argument("--mpiexec",default='mpirun',
 parser.add_argument('--test', metavar='test', type=int, nargs='+',
                     help='tests to run')
 
-parser.add_argument("--solve", action='store_true', default=False, 
+parser.add_argument("--solve", action='store_true', default=False,
                     help="Force solving on tests that use restart files.")
 args = parser.parse_args()
 
@@ -61,7 +61,7 @@ if args.mode == 'train':
         print('Running reference for test%d'%iTest)
         os.system('%s -np %d python tests/test%d.py %s > ref/%s_test%d_reg.ref 2>&1'%(
             args.mpiexec, args.procs, iTest, solveStr, module_name, iTest))
-            
+
     # If we're training, we done (no comparison)
     sys.exit(0)
 else:
@@ -104,7 +104,6 @@ else:
             os.system('cat %s >> adflow_reg.ref'%(refFile))
             os.system('cat %s >> adflow_reg'%(curFile))
             os.system('cat %s.orig >> adflow_reg.orig'%(curFile))
-                          
+
 # Exit with code equal to the number of failures
 sys.exit(masterRes)
-


### PR DESCRIPTION
The os.sys calls in run_reg_tests.py fail on the latest docker image (OpenMPI 3, Petsc 3.11, your branch with fixes). Separating out the file compare helper and MPI parallel write helper fixes the problem. I do not think it is docker specific but not sure.